### PR TITLE
Firefox keyboard fixes, Chrome layout hacks, black is better than grey

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
 <body>
 <div id="main">
 <span id="sec">
-<img src="img/wca_logo.svg" style="height: 80%">
+<img src="img/wca_logo.svg" class="splash">
 </span><br><span id="milli">
 </span>
 </div>

--- a/style.css
+++ b/style.css
@@ -58,7 +58,6 @@ html {
 }
 
 #main #milli {
-  display: inline-block;
   font-size: 10em;
   font-size: 20vh;
   height: 25%;
@@ -69,4 +68,8 @@ html {
 /* Using the regular (non-monospace) font for everything doesn't work for 11. */
 #main::first-letter {
   font-family: digital-7;
+}
+
+img.splash {
+  height: 80%;
 }

--- a/style.css
+++ b/style.css
@@ -58,6 +58,7 @@ html {
 }
 
 #main #milli {
+  display: inline-block;
   font-size: 10em;
   font-size: 20vh;
   height: 25%;

--- a/style.css
+++ b/style.css
@@ -15,6 +15,7 @@
   padding: 0;
   margin: 0;
   font-family: digital-7-mono, Helvetica, Tahoma, sans-serif;
+  color: black;
 
   -webkit-touch-callout: none;
   -webkit-user-select: none;

--- a/wca-inspection.js
+++ b/wca-inspection.js
@@ -1,7 +1,7 @@
 
 document.ontouchmove = function (event) {
     event.preventDefault();
-}
+};
 
 var state = "set";
 
@@ -42,6 +42,9 @@ function animFrame() {
     var now = Date.now();
     var time = Math.floor((now - startTime) / 1000);
     $("#sec").html(time);
+    // We don't want #milli to take up any space until we're ready to show it,
+    // which is right after we hid the splash image (on the previous line).
+    $("#milli").css("display", "inline-block");
     $("#milli").html(("000" + ((now - startTime) % 1000)).substr(-3));
 
     if (lastTime < 7 && time === 7) {

--- a/wca-inspection.js
+++ b/wca-inspection.js
@@ -100,7 +100,7 @@ function trigger(dir) {
 
 function keyboardHandler(dir, ev) {
   // Only trigger on spacebar.
-  if (ev.keyCode === 32) {
+  if (ev.which === 32) {
     trigger(dir);
   }
 }


### PR DESCRIPTION
A few things in here. Sorry for combining so many things into one pull request, but I don't have the time or inclination to learn git branching right now.

There's a tiny change to make the font color black, because firefox is apparently some dark grey by default.

This is a fix for #2 that got kind of ugly in order to avoid messing with the splash screen.

I also changed keyCode to which in the appropriate places so that firefox continues to work after the first start/stop. Apparently firefox sends a keyCode of 32 for keyup events, but _not_ for keypress events, which was causing some hard to root cause behavior. Here's console.log-ing of the relevant key events and state machine changes. I haven't taken the time to think about the statemachine transitions to evaluate if they're reasonable or not.

```
# First start works
09:42:23.602 "keypress 0" wca-inspection.js:103
09:42:23.680 "keyup 32" wca-inspection.js:103
09:42:23.681 "up" wca-inspection.js:85
09:42:23.681 "state" "go" wca-inspection.js:92

# First stop works
09:42:29.613 "keypress 0" wca-inspection.js:103
09:42:29.668 "keyup 32" wca-inspection.js:103
09:42:29.668 "up" wca-inspection.js:85
09:42:29.668 "state" "stop" wca-inspection.js:92

# Subsequent attempted start fails gets us from stop -> ready,
# but we can't get out of the ready state
09:42:39.051 "keypress 0" wca-inspection.js:103
09:42:39.130 "keyup 32" wca-inspection.js:103
09:42:39.130 "up" wca-inspection.js:85
09:42:39.130 "state" "ready" wca-inspection.js:92
09:42:43.481 "keypress 0" wca-inspection.js:103
09:42:43.584 "keyup 32" wca-inspection.js:103
09:42:43.584 "up" wca-inspection.js:85
09:42:43.585 "state" "ready" wca-inspection.js:92
09:43:09.750 "keypress 0" wca-inspection.js:103
09:43:09.850 "keyup 18" wca-inspection.js:103
09:43:14.408 "keyup 87" wca-inspection.js:103
09:43:14.471 "keyup 17" wca-inspection.js:103
09:43:16.481 "keyup 16" wca-inspection.js:103
09:43:16.519 "keyup 17" wca-inspection.js:103
09:43:16.950 "keypress 0" wca-inspection.js:103
09:43:17.013 "keyup 68" wca-inspection.js:103
```
